### PR TITLE
Support for named message parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Thor Generator
 
-[![GitHub release](https://img.shields.io/github/release/chillicream/thor-generator.svg)](https://github.com/ChilliCream/thor-generator/releases) [![NuGet Package](https://img.shields.io/nuget/v/Thor.Generator.svg)](https://www.nuget.org/packages/Thor.Generator/) [![Chocolatey Package](https://img.shields.io/chocolatey/v/Thor.Generator.svg)](https://chocolatey.org/packages/Thor.Generator/) [![License](https://img.shields.io/github/license/ChilliCream/thor-generator.svg)](https://github.com/ChilliCream/thor-generator/releases) [![Build](https://img.shields.io/appveyor/ci/rstaib/thor-generator/master.svg)](https://ci.appveyor.com/project/rstaib/thor-generator) [![Tests](https://img.shields.io/appveyor/tests/rstaib/thor-generator/master.svg)](https://ci.appveyor.com/project/rstaib/thor-generator) [![Coveralls](https://img.shields.io/coveralls/ChilliCream/thor-generator.svg)](https://coveralls.io/github/ChilliCream/thor-generator?branch=master)
+[![GitHub release](https://img.shields.io/github/release/chillicream/thor-generator.svg)](https://github.com/ChilliCream/thor-generator/releases) [![NuGet Package](https://img.shields.io/nuget/v/Thor.Generator.svg)](https://www.nuget.org/packages/Thor.Generator/) [![License](https://img.shields.io/github/license/ChilliCream/thor-generator.svg)](https://github.com/ChilliCream/thor-generator/releases) [![Build](https://img.shields.io/appveyor/ci/rstaib/thor-generator/master.svg)](https://ci.appveyor.com/project/rstaib/thor-generator) [![Tests](https://img.shields.io/appveyor/tests/rstaib/thor-generator/master.svg)](https://ci.appveyor.com/project/rstaib/thor-generator) [![Coveralls](https://img.shields.io/coveralls/ChilliCream/thor-generator.svg)](https://coveralls.io/github/ChilliCream/thor-generator?branch=master)
 
-*Thor Generator (ThorGen) is a generator for ETW (Event Tracing for Windows) event sources which helps avoid frequent mistakes and saves time.*
+_Thor Generator (ThorGen) is a generator for ETW (Event Tracing for Windows) event sources which helps avoid frequent mistakes and saves time._
 
 Microsoft's Event Tracing for Windows is a powerful tracing framework that offers minimal overhead and structured payloads.
 
@@ -12,7 +12,7 @@ The other problem with writing event sources is that one has to invest a lot of 
 
 ThorGen wants to solve these problems by generating the necessary event source code and letting developers focus on designing their tracing events around their business logic. ThorGen makes ETW easy to use and fast to implement.
 
-Event sources will be specified by writing interfaces that define the trace events and their payloads (no other DSL  needed, no context switch). The event source generator will inspect those interfaces and generate the necessary event source code.
+Event sources will be specified by writing interfaces that define the trace events and their payloads (no other DSL needed, no context switch). The event source generator will inspect those interfaces and generate the necessary event source code.
 
 The event source templates can be amended to fit your needs and your aesthetic point of view concerning the generated code.
 
@@ -20,43 +20,19 @@ At the moment, we offer two built-in templates to generate event sources in c#.
 
 ## Get Thor Generator
 
-### Build Integration
-
 We provide a nuget package that will integrate ThorGen with your project rather than relying on an installation. This will make it easy for developers who want to clone, build and get going rather than installing prerequisites.
 
-1. Install the ```Thor.Generator``` nuget package to the projects that contain event source interfaces.
+Install the `Thor.Generator` nuget package to the projects that contain event source interfaces.
 
 ```powershell
 Install-Package Thor.Generator
 ```
 
-2. With classic .net projects we will inject ThorGen into your project file and run ThorGen for this project before every build. With the new MSBuild projects used for .net core our package will be located in the global package cache. You can then either integrate our MSBuild task into your projects or use the ThorGen console from your build scripts.
-
 We have a walk through for both scenarious [here](https://github.com/ChilliCream/thor-generator-docs/blob/master/README.md).
-
-### Windows
-
-If you opt to install ThorGen on windows you can use chocolatey.
-
-```powershell
-choco install Thor.Generator
-```
-
-Chocolatey will add ThorGen to your path variable so that you can use it in any console you like.
-
-### macOS
-
-**Note: We are still working on our brew formula.**
-
-If you want to install ThorGen on macOS you can use brew.
-
-```bash
-brew install Thor.Generator
-```
 
 ## How to get started
 
-Open a project where you want to add your event sources and add an interface that declares the structure of the event source you want to create. Annotate your event source interface with a ```EventSourceDefinitionAttribute```. You can either use the attribute located in our [tracing core](https://www.nuget.org/packages/Thor.Abstractions) or create your own.
+Open a project where you want to add your event sources and add an interface that declares the structure of the event source you want to create. Annotate your event source interface with a `EventSourceDefinitionAttribute`. You can either use the attribute located in our [tracing core](https://www.nuget.org/packages/Thor.Abstractions) or create your own.
 
 ```csharp
 using System;
@@ -77,22 +53,17 @@ If you are using the msbuild integration of ThorGen just compile your project; o
 thorgen
 ```
 
-Or run ```thorgen -r``` if you want ThorGen to search recursively for any solution.
+Or run `thorgen -r` if you want ThorGen to search recursively for any solution.
 
 For a more detailed help that shows all the scenarious visit our [documentation](https://github.com/ChilliCream/thor-generator-docs/blob/master/README.md).
 
-
 ## Building the Repository
 
-| Windows               | macOS                 |
-| --------------------- | --------------------- |
-| [Instructions](https://github.com/ChilliCream/thor-generator-docs/blob/master/build/windows.md)      | [Instructions](https://github.com/ChilliCream/thor-generator-docs/blob/master/build/macos.md)      |
+| Windows | macOS |auto| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |auto| [Instructions](https://github.com/ChilliCream/thor-generator-docs/blob/master/build/windows.md) | [Instructions](https://github.com/ChilliCream/thor-generator-docs/blob/master/build/macos.md) |
 
 ### Build status of master branch
 
-| Platform               | Build               | Tests                 | Code Coverage         |
-| --------------------- | --------------------- | --------------------- | --------------------- |
-| Windows | [![AppVeyor branch](https://img.shields.io/appveyor/ci/rstaib/thor-generator/master.svg)](https://ci.appveyor.com/project/rstaib/thor-generator) | [![Tests](https://img.shields.io/appveyor/tests/rstaib/thor-generator/master.svg)](https://ci.appveyor.com/project/rstaib/thor-generator) | [![Coveralls](https://img.shields.io/coveralls/ChilliCream/thor-generator.svg)](https://coveralls.io/github/ChilliCream/thor-generator?branch=master) |
+| Platform | Build | Tests | Code Coverage |auto| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |auto| Windows | [![AppVeyor branch](https://img.shields.io/appveyor/ci/rstaib/thor-generator/master.svg)](https://ci.appveyor.com/project/rstaib/thor-generator) | [![Tests](https://img.shields.io/appveyor/tests/rstaib/thor-generator/master.svg)](https://ci.appveyor.com/project/rstaib/thor-generator) | [![Coveralls](https://img.shields.io/coveralls/ChilliCream/thor-generator.svg)](https://coveralls.io/github/ChilliCream/thor-generator?branch=master) |
 
 ## Legal and Licensing
 

--- a/src/Generator.Tests/EventSourceModelPostProcessorTests.cs
+++ b/src/Generator.Tests/EventSourceModelPostProcessorTests.cs
@@ -44,6 +44,45 @@ namespace Thor.Generator
         }
 
         [Fact]
+        public void ReplaceNamedParameters()
+        {
+            // arrange
+            Template template = new Template(Guid.NewGuid().ToString("N"),
+                Guid.NewGuid().ToString("N"),
+                Enumerable.Empty<WriteMethod>(),
+                Enumerable.Empty<NamespaceModel>(),
+                5, false, null);
+
+            EventSourceModel eventSourceModel = new EventSourceModel();
+            EventModel eventModel = new EventModel();
+            eventModel.Attribute.Properties.Add(new AttributePropertyModel
+            {
+                Name = "Message",
+                Value = "{foo} {bar}"
+            });
+            eventModel.InputParameters.Add(new EventParameterModel
+            {
+                Name = "foo",
+                Type = "string"
+            });
+            eventModel.InputParameters.Add(new EventParameterModel
+            {
+                Name = "bar",
+                Type = "int"
+            });
+            eventSourceModel.Events.Add(eventModel);
+
+            // act
+            EventSourceModelPostProcessor postProcessor
+                = new EventSourceModelPostProcessor(template);
+            postProcessor.Process(eventSourceModel);
+
+            // assert
+            Assert.Equal("{5} {6}",
+                eventModel.Attribute.Properties.First().Value);
+        }
+
+        [Fact]
         public void CheckComplexParameter()
         {
             // arrange

--- a/src/Generator.Tests/MessageParserTests.cs
+++ b/src/Generator.Tests/MessageParserTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Thor.Generator.Templates;
 using Xunit;
 
@@ -8,13 +9,15 @@ namespace Thor.Generator
     public class MessageParserTests
     {
         [Fact]
-        public void Parse()
+        public void FindPlaceholders()
         {
             // arrange
-            string message = "{foo:c} {foo:c:sjkfj_fjd:shjhda} {foo} {a}{b} {{escaped}} {{{not-escaped}}}";
+            string message = "{foo:c} {foo:c:sjkfj_fjd:shjhda} {foo} {a}{b} " +
+                "{{escaped}} {{{not-escaped}}}";
 
             // act
-            Placeholder[] placeholders = MessageParser.FindPlaceholders(message).ToArray();
+            Placeholder[] placeholders =
+                MessageParser.FindPlaceholders(message).ToArray();
 
             // assert
             Assert.Collection(placeholders,
@@ -28,38 +31,115 @@ namespace Thor.Generator
                 t =>
                 {
                     Assert.Equal(8, t.Start);
-                    Assert.Equal(6, t.End);
+                    Assert.Equal(31, t.End);
                     Assert.Equal("foo", t.Name);
                     Assert.Equal("c:sjkfj_fjd:shjhda", t.Format);
                 },
                 t =>
                 {
-                    Assert.Equal(0, t.Start);
-                    Assert.Equal(6, t.End);
+                    Assert.Equal(33, t.Start);
+                    Assert.Equal(37, t.End);
                     Assert.Equal("foo", t.Name);
                     Assert.Null(t.Format);
                 },
                 t =>
                 {
-                    Assert.Equal(0, t.Start);
-                    Assert.Equal(6, t.End);
+                    Assert.Equal(39, t.Start);
+                    Assert.Equal(41, t.End);
                     Assert.Equal("a", t.Name);
                     Assert.Null(t.Format);
                 },
                 t =>
                 {
-                    Assert.Equal(0, t.Start);
-                    Assert.Equal(6, t.End);
+                    Assert.Equal(42, t.Start);
+                    Assert.Equal(44, t.End);
                     Assert.Equal("b", t.Name);
                     Assert.Null(t.Format);
                 },
                 t =>
                 {
-                    Assert.Equal(0, t.Start);
-                    Assert.Equal(6, t.End);
+                    Assert.Equal(60, t.Start);
+                    Assert.Equal(72, t.End);
                     Assert.Equal("not-escaped", t.Name);
                     Assert.Null(t.Format);
                 });
+        }
+
+        [Fact]
+        public void ReplacePlaceholders()
+        {
+            // arrange
+            string message =
+                "{foo:c} {foo:c:sjkfj_fjd:shjhda} {foo} {a}{b} " +
+                "{{z}} {{{z}}}";
+
+            Placeholder[] placeholders =
+                MessageParser.FindPlaceholders(message).ToArray();
+
+            // act
+            int i = 0;
+            string newMessage = MessageParser.ReplacePlaceholders(
+                message,
+                placeholders,
+                p => p.ToString(i++));
+
+            // assert
+            string expectedMessage =
+                "{0:c} {1:c:sjkfj_fjd:shjhda} {2} {3}{4} " +
+                "{{z}} {{{5}}}";
+            Assert.Equal(expectedMessage, newMessage);
+        }
+
+        [Fact]
+        public void Placeholder_ToString_NoFormat()
+        {
+            // arrange
+            Placeholder placeholder = new Placeholder(0, 0, "foo");
+
+            // act
+            string result = placeholder.ToString();
+
+            // assert
+            Assert.Equal("{foo}", result);
+        }
+
+        [Fact]
+        public void Placeholder_ToString_WithFormat()
+        {
+            // arrange
+            Placeholder placeholder = new Placeholder(0, 0, "foo", "format");
+
+            // act
+            string result = placeholder.ToString();
+
+            // assert
+            Assert.Equal("{foo:format}", result);
+        }
+
+        [Fact]
+        public void Placeholder_ToStringIndex_NoFormat()
+        {
+            // arrange
+            Placeholder placeholder = new Placeholder(0, 0, "foo");
+
+            // act
+            string result = placeholder.ToString(1);
+
+            // assert
+            Assert.Equal("{1}", result);
+        }
+
+        [Fact]
+        public void Placeholder_ToStringIndex_WithFormat()
+        {
+            // arrange
+            Placeholder placeholder = new Placeholder(0, 0, "foo", "format");
+
+            // act
+            string result = placeholder.ToString(1);
+
+            // assert
+            Assert.Equal("{1:format}", result);
         }
     }
 }

--- a/src/Generator.Tests/MessageParserTests.cs
+++ b/src/Generator.Tests/MessageParserTests.cs
@@ -66,6 +66,35 @@ namespace Thor.Generator
         }
 
         [Fact]
+        public void IgnoreIndexBasedPlaceholders()
+        {
+            // arrange
+            string message = "{foo:c} {1:c:sjkfj_fjd:shjhda} {0} {a}";
+
+            // act
+            Placeholder[] placeholders =
+                MessageParser.FindPlaceholders(message).ToArray();
+
+            // assert
+            Assert.Collection(placeholders,
+                t =>
+                {
+                    Assert.Equal(0, t.Start);
+                    Assert.Equal(6, t.End);
+                    Assert.Equal("foo", t.Name);
+                    Assert.Equal("c", t.Format);
+                },
+                t =>
+                {
+                    Assert.Equal(35, t.Start);
+                    Assert.Equal(37, t.End);
+                    Assert.Equal("a", t.Name);
+                    Assert.Null(t.Format);
+                });
+        }
+
+
+        [Fact]
         public void ReplacePlaceholders()
         {
             // arrange

--- a/src/Generator.Tests/MessageParserTests.cs
+++ b/src/Generator.Tests/MessageParserTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+using Thor.Generator.Templates;
+using Xunit;
+
+namespace Thor.Generator
+{
+    public class MessageParserTests
+    {
+        [Fact]
+        public void Parse()
+        {
+            // arrange
+            string message = "{foo:c} {foo:c:sjkfj_fjd:shjhda} {foo} {a}{b} {{escaped}} {{{not-escaped}}}";
+
+            // act
+            Placeholder[] placeholders = MessageParser.FindPlaceholders(message).ToArray();
+
+            // assert
+            Assert.Collection(placeholders,
+                t =>
+                {
+                    Assert.Equal(0, t.Start);
+                    Assert.Equal(6, t.End);
+                    Assert.Equal("foo", t.Name);
+                    Assert.Equal("c", t.Format);
+                },
+                t =>
+                {
+                    Assert.Equal(8, t.Start);
+                    Assert.Equal(6, t.End);
+                    Assert.Equal("foo", t.Name);
+                    Assert.Equal("c:sjkfj_fjd:shjhda", t.Format);
+                },
+                t =>
+                {
+                    Assert.Equal(0, t.Start);
+                    Assert.Equal(6, t.End);
+                    Assert.Equal("foo", t.Name);
+                    Assert.Null(t.Format);
+                },
+                t =>
+                {
+                    Assert.Equal(0, t.Start);
+                    Assert.Equal(6, t.End);
+                    Assert.Equal("a", t.Name);
+                    Assert.Null(t.Format);
+                },
+                t =>
+                {
+                    Assert.Equal(0, t.Start);
+                    Assert.Equal(6, t.End);
+                    Assert.Equal("b", t.Name);
+                    Assert.Null(t.Format);
+                },
+                t =>
+                {
+                    Assert.Equal(0, t.Start);
+                    Assert.Equal(6, t.End);
+                    Assert.Equal("not-escaped", t.Name);
+                    Assert.Null(t.Format);
+                });
+        }
+    }
+}

--- a/src/Generator/Templates/EventSourceModelPostProcessor.cs
+++ b/src/Generator/Templates/EventSourceModelPostProcessor.cs
@@ -64,7 +64,8 @@ namespace Thor.Generator.Templates
             // 3. Generate the list of usings from the two input sources: Template usings and Interface (input file) usings
             MergeUsings(eventSourceModel);
 
-
+            // 4. Replace named placeholders
+            ReplaceMessagePlaceholdersWithIndexes(eventSourceModel);
         }
 
         /// <summary>
@@ -94,6 +95,7 @@ namespace Thor.Generator.Templates
                 eventModel.Attribute.Properties
                     .FirstOrDefault(t => t.Name.Equals("Message",
                         StringComparison.Ordinal));
+
             if (messageProperty != null
                 && !string.IsNullOrEmpty(messageProperty.Value))
             {

--- a/src/Generator/Templates/EventSourceModelPostProcessor.cs
+++ b/src/Generator/Templates/EventSourceModelPostProcessor.cs
@@ -94,32 +94,48 @@ namespace Thor.Generator.Templates
                 eventModel.Attribute.Properties
                     .FirstOrDefault(t => t.Name.Equals("Message",
                         StringComparison.Ordinal));
-            if (messageProperty != null)
+            if (messageProperty != null
+                && !string.IsNullOrEmpty(messageProperty.Value))
             {
-                ILookup<string, Placeholder> placeholderLookup =
+                Placeholder[] placeholders =
                     MessageParser.FindPlaceholders(messageProperty.Value)
-                        .ToLookup(t => t.Name);
+                        .ToArray();
 
-                int offset = _template.DefaultPayloads;
-                StringBuilder message = new StringBuilder(messageProperty.Value);
+                Dictionary<Placeholder, string> values =
+                    CreatePlaceholderValues(eventModel, placeholders);
 
-                for (int i = 0; i < eventModel.InputParameters.Count; i++)
-                {
-                    string name = eventModel.InputParameters[i].Name;
-                    foreach (Placeholder placeholder in placeholderLookup[name])
-                    {
-                        int index = i + offset;
-                        message.Replace(
-                            placeholder.ToString(),
-                            placeholder.ToString(index));
-                    }
-                }
-
-                messageProperty.Value = message.ToString();
+                messageProperty.Value = MessageParser.ReplacePlaceholders(
+                    messageProperty.Value,
+                    placeholders,
+                    p => values[p]);
             }
         }
 
+        private Dictionary<Placeholder, string> CreatePlaceholderValues(
+            EventModel eventModel,
+            IEnumerable<Placeholder> placeholders)
+        {
+            ILookup<string, Placeholder> placeholderLookup =
+                    placeholders.ToLookup(t => t.Name);
 
+            int offset = _template.DefaultPayloads;
+
+            Dictionary<Placeholder, string> values =
+                new Dictionary<Placeholder, string>();
+
+            for (int i = 0; i < eventModel.InputParameters.Count; i++)
+            {
+                string name = eventModel.InputParameters[i].Name;
+                int index = i + offset;
+
+                foreach (Placeholder placeholder in placeholderLookup[name])
+                {
+                    values[placeholder] = placeholder.ToString(index);
+                }
+            }
+
+            return values;
+        }
 
         private void QualifyParameters(EventSourceModel eventSourceModel)
         {
@@ -234,113 +250,6 @@ namespace Thor.Generator.Templates
                 throw new ArgumentException("The specified type is not allowed.", nameof(typeName));
             }
             return typeInfo;
-        }
-    }
-
-    internal class MessageParser
-    {
-        public static IEnumerable<Placeholder> FindPlaceholders(string message)
-        {
-            int position = 0;
-            while (Skip(message, '{', ref position))
-            {
-                int start = position;
-
-                if (Peek(message, '{', start))
-                {
-                    position += 2;
-                    continue;
-                }
-                else if (Skip(message, '}', ref position))
-                {
-                    yield return ParsePlaceholder(
-                        start,
-                        position,
-                        message.Substring(
-                            start + 1,
-                            position - start - 1));
-                }
-            }
-        }
-
-        private static Placeholder ParsePlaceholder(
-            int start,
-            int end,
-            string placeholder)
-        {
-            int index = 0;
-
-            if (Skip(placeholder, ':', ref index))
-            {
-                return new Placeholder(
-                    start,
-                    end,
-                    placeholder.Substring(0, index),
-                    placeholder.Substring(index + 1));
-            }
-
-            return new Placeholder(start, end, placeholder);
-        }
-
-        private static bool Skip(string message, char token, ref int position)
-        {
-            while (position < message.Length && message[position] != token)
-            {
-                position++;
-            }
-
-            return (position < message.Length && message[position] == token);
-        }
-
-        private static bool Peek(string message, char token, int position)
-        {
-            int next = position + 1;
-            return message.Length > next
-                && message[next] == token;
-        }
-    }
-
-    internal class Placeholder
-    {
-        public Placeholder(int start, int end, string name)
-        {
-            Start = start;
-            End = end;
-            Name = name;
-        }
-
-        public Placeholder(int start, int end, string name, string format)
-        {
-            Start = start;
-            End = end;
-            Name = name;
-            Format = format;
-        }
-
-        public int Start { get; }
-
-        public int End { get; }
-
-        public string Name { get; }
-
-        public string Format { get; }
-
-        public override string ToString()
-        {
-            if (Format == null)
-            {
-                return $"{{{Name}}}";
-            }
-            return $"{{{Name}:{Format}}}";
-        }
-
-        public string ToString(int index)
-        {
-            if (Format == null)
-            {
-                return $"{{{index}}}";
-            }
-            return $"{{{index}:{Format}}}";
         }
     }
 }

--- a/src/Generator/Templates/MessageParser.cs
+++ b/src/Generator/Templates/MessageParser.cs
@@ -21,12 +21,17 @@ namespace Thor.Generator.Templates
                 }
                 else if (Skip(message, '}', ref position))
                 {
-                    yield return ParsePlaceholder(
+                    Placeholder placeholder = ParsePlaceholder(
                         start,
                         position,
                         message.Substring(
                             start + 1,
                             position - start - 1));
+
+                    if (placeholder.IsNameBased())
+                    {
+                        yield return placeholder;
+                    }
                 }
             }
         }

--- a/src/Generator/Templates/MessageParser.cs
+++ b/src/Generator/Templates/MessageParser.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Thor.Generator.Templates
+{
+    internal class MessageParser
+    {
+        public static IEnumerable<Placeholder> FindPlaceholders(
+            string message)
+        {
+            int position = 0;
+            while (Skip(message, '{', ref position))
+            {
+                int start = position;
+
+                if (Peek(message, '{', start))
+                {
+                    position += 2;
+                    continue;
+                }
+                else if (Skip(message, '}', ref position))
+                {
+                    yield return ParsePlaceholder(
+                        start,
+                        position,
+                        message.Substring(
+                            start + 1,
+                            position - start - 1));
+                }
+            }
+        }
+
+        public static string ReplacePlaceholders(
+            string message,
+            IReadOnlyCollection<Placeholder> placeholders,
+            Func<Placeholder, string> getValue)
+        {
+            StringBuilder newMessage = new StringBuilder();
+            int last = 0;
+
+            foreach (Placeholder placeholder in placeholders)
+            {
+                if (last < placeholder.Start && last < placeholder.Start - 1)
+                {
+                    newMessage.Append(message.Substring(last + 1, placeholder.Start - last - 1));
+                    last = placeholder.Start;
+                }
+
+                newMessage.Append(getValue(placeholder));
+                last = placeholder.End;
+            }
+
+            if (last < message.Length)
+            {
+                newMessage.Append(message.Substring(last + 1));
+            }
+
+            return newMessage.ToString();
+        }
+
+        private static Placeholder ParsePlaceholder(
+            int start,
+            int end,
+            string placeholder)
+        {
+            int index = 0;
+
+            if (Skip(placeholder, ':', ref index))
+            {
+                return new Placeholder(
+                    start,
+                    end,
+                    placeholder.Substring(0, index),
+                    placeholder.Substring(index + 1));
+            }
+
+            return new Placeholder(start, end, placeholder);
+        }
+
+        private static bool Skip(string message, char token, ref int position)
+        {
+            while (position < message.Length && message[position] != token)
+            {
+                position++;
+            }
+
+            return (position < message.Length && message[position] == token);
+        }
+
+        private static bool Peek(string message, char token, int position)
+        {
+            int next = position + 1;
+            return message.Length > next
+                && message[next] == token;
+        }
+    }
+}

--- a/src/Generator/Templates/Placeholder.cs
+++ b/src/Generator/Templates/Placeholder.cs
@@ -25,6 +25,9 @@ namespace Thor.Generator.Templates
 
         public string Format { get; }
 
+        public bool IsIndexBased() => int.TryParse(Name, out var _);
+        public bool IsNameBased() => !IsIndexBased();
+
         public override string ToString()
         {
             if (Format == null)

--- a/src/Generator/Templates/Placeholder.cs
+++ b/src/Generator/Templates/Placeholder.cs
@@ -1,0 +1,46 @@
+namespace Thor.Generator.Templates
+{
+    internal class Placeholder
+    {
+        public Placeholder(int start, int end, string name)
+        {
+            Start = start;
+            End = end;
+            Name = name;
+        }
+
+        public Placeholder(int start, int end, string name, string format)
+        {
+            Start = start;
+            End = end;
+            Name = name;
+            Format = format;
+        }
+
+        public int Start { get; }
+
+        public int End { get; }
+
+        public string Name { get; }
+
+        public string Format { get; }
+
+        public override string ToString()
+        {
+            if (Format == null)
+            {
+                return $"{{{Name}}}";
+            }
+            return $"{{{Name}:{Format}}}";
+        }
+
+        public string ToString(int index)
+        {
+            if (Format == null)
+            {
+                return $"{{{index}}}";
+            }
+            return $"{{{index}:{Format}}}";
+        }
+    }
+}


### PR DESCRIPTION
The message attribute property only supports index based parameters. Since working with indexes is very error prone we want to allow the user to use the payload names as placeholders.

Currently a event source definition works like the following:

```csharp
[EventDefinition]
public interface IFoo 
{
   [Event(0, Message = "bla blub {0} ....")]
    void Bar(string baz);
}
```

With named parameters our new event template would now look like the following:

```csharp
[EventDefinition]
public interface IFoo 
{
   [Event(0, Message = "bla blub {baz} ....")]
    void Bar(string baz);
}
```

The named placeholders are replaced by the generator to the index based and users can still use the indexed based placeholders if they choose to do so.